### PR TITLE
feat: add video_url and audio_url support for ContentGeneration content items   

### DIFF
--- a/service/arkruntime/model/content_generation.go
+++ b/service/arkruntime/model/content_generation.go
@@ -7,6 +7,8 @@ type ContentGenerationContentItemType string
 const (
 	ContentGenerationContentItemTypeText      ContentGenerationContentItemType = "text"
 	ContentGenerationContentItemTypeImage     ContentGenerationContentItemType = "image_url"
+	ContentGenerationContentItemTypeVideo     ContentGenerationContentItemType = "video_url"
+	ContentGenerationContentItemTypeAudio     ContentGenerationContentItemType = "audio_url"
 	ContentGenerationContentItemTypeDraftTask ContentGenerationContentItemType = "draft_task"
 )
 
@@ -117,6 +119,8 @@ type CreateContentGenerationContentItem struct {
 	Type      ContentGenerationContentItemType `json:"type"`
 	Text      *string                          `json:"text,omitempty"`
 	ImageURL  *ImageURL                        `json:"image_url,omitempty"`
+	VideoURL  *VideoURL                        `json:"video_url,omitempty"`
+	AudioURL  *AudioURL                        `json:"audio_url,omitempty"`
 	Role      *string                          `json:"role,omitempty"`
 	DraftTask *DraftTask                       `json:"draft_task,omitempty"`
 }
@@ -128,6 +132,15 @@ type DraftTask struct {
 type ImageURL struct {
 	URL string `json:"url"`
 }
+
+type VideoURL struct {
+	URL string `json:"url"`
+}
+
+type AudioURL struct {
+	URL string `json:"url"`
+}
+
 type Content struct {
 	VideoURL     string `json:"video_url"`
 	LastFrameURL string `json:"last_frame_url"`


### PR DESCRIPTION
## Summary                                                                                                                                                                                                             
                                                                 
  Add `video_url` and `audio_url` content item types to `CreateContentGenerationContentItem` for the Content Generation API.                                                                                             
   
  The current struct only supports `text`, `image_url`, and `draft_task` content types. However, the [Seedance API](https://www.volcengine.com/docs/82379/1520757?lang=zh) supports `video_url` and `audio_url` as input content 
  types. When using these types, the data is silently dropped during JSON unmarshal/marshal because the struct has no corresponding fields.
                                                                                                                                                                                                                         
  ## Changes                                                                                                                                                                                                             
                                                
  - Added `ContentGenerationContentItemTypeVideo` and `ContentGenerationContentItemTypeAudio` type constants                                                                                                             
  - Added `VideoURL *VideoURL` and `AudioURL *AudioURL` fields to `CreateContentGenerationContentItem`
  - Added `VideoURL` and `AudioURL` structs (same structure as `ImageURL`)     
