### PR TITLE
fix(arkruntime): pass custom HTTP client to ark SDK config

### DIFF
--- a/service/arkruntime/client.go
+++ b/service/arkruntime/client.go
@@ -59,7 +59,8 @@ func newClientWithConfig(config clientConfig) *Client {
 	var arkClient *ark.ARK
 	arkConfig := volcengine.NewConfig().
 		WithCredentials(credentials.NewStaticCredentials(config.ak, config.sk, "")).
-		WithRegion(config.region)
+		WithRegion(config.region).
+		WithHTTPClient(config.HTTPClient)
 
 	sess, _ := session.NewSession(arkConfig)
 	arkClient = ark.New(sess)


### PR DESCRIPTION
Pass the arkruntime configured HTTP client into the underlying Ark SDK config.

## Background

Some internal environments customize `http.DefaultTransport`, for example by injecting `telemetry.roundTripperFunc`.

Before this change, the arkruntime client stored a configured `HTTPClient`, but did not pass it to the underlying Ark SDK client. The Ark SDK could then use the customized default transport and fail at runtime.

## Change

Add `WithHTTPClient(config.HTTPClient)` when building the Ark SDK config in `newClientWithConfig`.

## Validation

```bash
GOCACHE=/private/tmp/volcengine-go-build-cache GOMODCACHE=/private/tmp/volcengine-go-mod-cache go test ./service/arkruntime/...